### PR TITLE
Split Directory by Testament

### DIFF
--- a/src/content/post/matthew.md
+++ b/src/content/post/matthew.md
@@ -2,7 +2,7 @@
 title: "Matthew"
 publishDate: "5 March 2026"
 pageType: "bibleChapter"
-tags: []
+tags: ["new testament"]
 people: []
 outline: []
 ---

--- a/src/pages/directory/index.astro
+++ b/src/pages/directory/index.astro
@@ -12,7 +12,7 @@ import {
 
 const bibleChapters = await getAllBibleChapters();
 const allPosts = await getAllPosts();
-const sortedChapters = sortBibleChapterPosts(bibleChapters);
+const { oldTestament, newTestament } = sortBibleChapterPosts(bibleChapters);
 const otherPosts = filterForOtherPosts(allPosts);
 const uniqueTags = getUniqueTags(allPosts);
 const uniquePeople = getUniquePeople(allPosts);
@@ -28,17 +28,28 @@ const meta = {
 	<div class="grid gap-y-16 sm:grid-cols-[4fr_1fr] sm:gap-x-8">
 		<section>
 			<h2 class="mb-8">Books of the Bible</h2>
-			<ul class="space-y-8 text-start">
+			<h3 class="mb-6">Old Testament</h3>
+			<ul class="mb-8 space-y-6 text-start">
 				{
-					sortedChapters.map((p) => (
+					oldTestament.map((p) => (
 						<li class="flex flex-col flex-wrap gap-2 sm:flex-row [&_q]:basis-full">
 							<PostPreview post={p} as="h2" withDesc />
 						</li>
 					))
 				}
 			</ul>
-			<h2 class="my-8">Non-Biblical Resources</h2>
-			<ul class="space-y-8 text-start">
+			<h3 class="mb-6">New Testament</h3>
+			<ul class="mb-8 space-y-6 text-start">
+				{
+					newTestament.map((p) => (
+						<li class="flex flex-col flex-wrap gap-2 sm:flex-row [&_q]:basis-full">
+							<PostPreview post={p} as="h2" withDesc />
+						</li>
+					))
+				}
+			</ul>
+			<h2 class="mb-6">Non-Biblical Resources</h2>
+			<ul class="space-y-6 text-start">
 				{
 					otherPosts.map((p) => (
 						<li class="flex flex-col flex-wrap gap-2 sm:flex-row [&_q]:basis-full">

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -97,11 +97,26 @@ export function filterForOtherPosts(posts: Array<CollectionEntry<"post">>) {
 
 export function sortBibleChapterPosts(posts: Array<CollectionEntry<"post">>) {
 	// sort the list of posts by title in order of BIBLE_BOOKS
-	return posts.sort((a, b) => {
+	const sortedPosts = posts.sort((a, b) => {
 		const aIndex = BIBLE_BOOKS.indexOf(a.data.title);
 		const bIndex = BIBLE_BOOKS.indexOf(b.data.title);
+
 		return aIndex - bIndex;
 	});
+
+	const oldTestament = sortedPosts.filter(function (p) {
+		const hasNewTestament = p.data.tags.some((tag) => tag === "new testament");
+
+		return !hasNewTestament;
+	});
+
+	const newTestament = sortedPosts.filter(function (p) {
+		const hasNewTestament = p.data.tags.some((tag) => tag === "new testament");
+
+		return hasNewTestament;
+	});
+
+	return { oldTestament, newTestament };
 }
 
 export function sortMDByDate(posts: Array<CollectionEntry<"post">>) {


### PR DESCRIPTION
The purpose of this pull request is to split the display of books in the directory page by old and new testament. The sorting convenience function was modified to filter by whether a `'new testament'` tag exists in the `tags`.